### PR TITLE
校对Tooltips

### DIFF
--- a/SOURCE/components/tooltips.md
+++ b/SOURCE/components/tooltips.md
@@ -60,3 +60,5 @@ src="http://materialdesign.qiniudn.com/videos/components-tooltips-cursorkeyboard
 ![](images/components-tooltips-touchuitooltips-tooltips_19a_large_mdpi.png)
 
 ![](images/components-tooltips-touchuitooltips-tooltips_19b_large_mdpi.png)
+
+> 原文：[Tooltips](http://www.google.com/design/spec/components/tooltips.html)  翻译：[lhyqy5](https://github.com/lhyqy5)  校对：[PoppinLp](https://github.com/poppinlp)


### PR DESCRIPTION
- 标题和H1里有工具提示（Tooltips）了，就把后文中这个括号里的英文删掉了
- 后面一些分段了的图片去掉了行尾的空格
